### PR TITLE
auto-get READERS and WRITERS

### DIFF
--- a/pyexcel_io/__init__.py
+++ b/pyexcel_io/__init__.py
@@ -314,3 +314,36 @@ def get_data(afile, file_type=None, streaming=False, **keywords):
         return list(data.values())[0]
     else:
         return data
+
+try:
+    from pyexcel_xls import XLS_WRITERS, XLS_READERS
+    WRITERS.update(XLS_WRITERS)
+    READERS.update(XLS_READERS)
+except ImportError:
+    pass
+
+try:
+    from pyexcel_xlsx import XLSX_WRITERS, XLSX_READERS
+    WRITERS.update(XLSX_WRITERS)
+    READERS.update(XLSX_READERS)
+except ImportError:
+    pass
+
+try:
+    from pyexcel_ods import ODS_WRITERS, ODS_READERS
+    WRITERS.update(ODS_WRITERS)
+    READERS.update(ODS_READERS)
+except ImportError:
+    pass
+
+try:
+    from pyexcel_text import ODS3_WRITERS, ODS3_READERS
+    WRITERS.update(ODS3_WRITERS)
+    READERS.update(ODS3_READERS)
+except ImportError:
+    pass
+try:
+    from pyexcel_text.writers import TEXT_WRITERS
+    WRITERS.update(TEXT_WRITERS)
+except ImportError:
+    pass


### PR DESCRIPTION
I was experimenting with this awhile ago.

I stopped when I realized it would take a good bit of refactoring of the `pyexcel_*` libraries to get it to work. Basically the issue involves circular imports - we'd need to start moving things out of `__init__.py` and into a `base.py` (or similar) module around the board.

The advantage to this is that, as a user, you would no longer need to explicitly import all the `pyexcel_*` packages at the top of wherever you want to use it. You would only need to have them installed at the `PYTHONPATH` level.

Let me know what you think.